### PR TITLE
Exclude uniqid generation from realpath expansion.

### DIFF
--- a/src/Media/Process/Adapter/FfmpegShell.php
+++ b/src/Media/Process/Adapter/FfmpegShell.php
@@ -264,7 +264,7 @@ class FfmpegShell extends \mm\Media\Process\Adapter {
 	}
 
 	protected function _tempFile() {
-		return realpath((ini_get('sys_temp_dir') ?: sys_get_temp_dir()) . '/' . uniqid('mm_'));
+		return realpath(ini_get('sys_temp_dir') ?: sys_get_temp_dir()) . '/' . uniqid('mm_');
 	}
 }
 

--- a/src/Media/Process/Adapter/SoxShell.php
+++ b/src/Media/Process/Adapter/SoxShell.php
@@ -158,7 +158,7 @@ class SoxShell extends \mm\Media\Process\Adapter {
 	}
 
 	protected function _tempFile() {
-		return realpath((ini_get('sys_temp_dir') ?: sys_get_temp_dir()) . '/' . uniqid('mm_'));
+		return realpath(ini_get('sys_temp_dir') ?: sys_get_temp_dir()) . '/' . uniqid('mm_');
 	}
 }
 


### PR DESCRIPTION
This fixes handling of uniqids in combination with realpaths.