### PR TITLE
Support PHP 8.x GdImage Object

### DIFF
--- a/src/Media/Process/Adapter/Gd.php
+++ b/src/Media/Process/Adapter/Gd.php
@@ -326,7 +326,7 @@ class Gd extends \mm\Media\Process\Adapter {
 	}
 
 	protected function _isResource($image) {
-		return is_resource($image) && get_resource_type($image) == 'gd';
+		return is_resource($image) && get_resource_type($image) == 'gd' || $image instanceof \GdImage;
 	}
 
 	protected function _isTransparent($image) {


### PR DESCRIPTION
GD functions returns GdImage instance from PHP 8.x.
This pull request check GdImage in `Gd::_isResource` method.